### PR TITLE
Allow multiple values for a parameter

### DIFF
--- a/python_http_client/client.py
+++ b/python_http_client/client.py
@@ -98,7 +98,7 @@ class Client(object):
             url += '/{0}'.format(self._url_path[count])
             count += 1
         if query_params:
-            url_values = urlencode(sorted(query_params.items()))
+            url_values = urlencode(sorted(query_params.items()), True)
             url = '{0}?{1}'.format(url, url_values)
         url = self._build_versioned_url(url) if self._version else self.host + url
         return url

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -93,8 +93,8 @@ class TestClient(unittest.TestCase):
         self.client._version = 3
         url = '{0}/v{1}{2}'.format(self.host,
                                    str(self.client._version),
-                                   '/here/there/1?hello=0&world=1')
-        query_params = {'hello': 0, 'world': 1}
+                                   '/here/there/1?hello=0&world=1&ztest=0&ztest=1')
+        query_params = {'hello': 0, 'world': 1, 'ztest': [0,1]}
         built_url = self.client._build_url(query_params)
         self.assertEqual(built_url, url)
 


### PR DESCRIPTION
This is a fix for https://github.com/sendgrid/sendgrid-python/issues/186