### PR TITLE
Added License link to README ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you are looking for the SendGrid API client library, please see [this repo](h
 * [Announcements](#announcements)
 * [Thanks](#thanks)
 * [About](#about)
+* [License](#license)
 
 <a name="installation"></a>
 # Installation
@@ -115,6 +116,7 @@ python-http-client is guided and supported by the SendGrid [Developer Experience
 
 python-http-client is maintained and funded by SendGrid, Inc. The names and logos for python-http-client are trademarks of SendGrid, Inc.
 
+<a name="license"></a>
 # License
 
 [The MIT License (MIT)](LICENSE.txt)


### PR DESCRIPTION
Hi, I noticed that the License link in the Table of Contents was missing, while usually the other sendgrid  repositories' Table of Contents had a link to License; so I added it. Let me know what else I can do to help.