### PR TITLE
Add missing Travis-CI python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 fail_fast: true
 before_install:
     - pip install pycodestyle


### PR DESCRIPTION
Build (all python interpreter versions) passed, following link provided below:
https://travis-ci.org/duboviy/python-http-client

[Additional Note]:
Python 3.7 can't be added right now due to Travis-CI issue:
https://github.com/travis-ci/travis-ci/issues/9815
Python 3.7 could be added now only with dirty workaround: `dist: xenial & sudo: true` need to be specified (I'd suggest to wait https://github.com/travis-ci/travis-ci/issues/9815 fixed and add 3.7 normally in separate PR).

