### PR TITLE
Fix a year in LICENSE.txt file to fix test__daterange.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012 - 2018 SendGrid, Inc.
+Copyright (c) 2012 - 2019 SendGrid, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hello.

Because the test `test__daterange` rely on the current year in the license file, the LICENSE.txt should be updated every year because otherwise the test will be broken.

Honestly, I don't think that test like this is a good idea but it's up to you.