### PR TITLE
Let test_datarange show only a warning instead of fail on AssertionError

### DIFF
--- a/tests/test_daterange.py
+++ b/tests/test_daterange.py
@@ -1,6 +1,7 @@
 import os
 import time
 import unittest
+import warnings
 
 
 class DateRangeTest(unittest.TestCase):
@@ -15,4 +16,7 @@ class DateRangeTest(unittest.TestCase):
         fh.close()
 
     def test__daterange(self):
-        self.assertIn(self.pattern, self.licensefile)
+        try:
+            self.assertIn(self.pattern, self.licensefile)
+        except AssertionError:
+            warnings.warn("License file does not contain a current year!")


### PR DESCRIPTION
I think that the subject says it all.

Fixes: https://github.com/sendgrid/python-http-client/issues/121
