### PR TITLE
fix: Remove ResourceWarning on module import

### DIFF
--- a/python_http_client/__init__.py
+++ b/python_http_client/__init__.py
@@ -19,4 +19,5 @@ from .exceptions import (  # noqa
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 if os.path.isfile(os.path.join(dir_path, 'VERSION.txt')):
-    __version__ = open(os.path.join(dir_path, 'VERSION.txt')).read().strip()
+    with open(os.path.join(dir_path, 'VERSION.txt')) as version_file:
+        __version__ = version_file.read().strip()

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,10 @@ from setuptools import find_packages, setup
 
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
-readme = io.open(os.path.join(dir_path, 'README.rst'), encoding='utf-8').read()
-version = io.open(os.path.join(dir_path, 'VERSION.txt'),
-                  encoding='utf-8').read().strip()
+with io.open(os.path.join(dir_path, 'README.rst'), encoding='utf-8') as readme_file:
+    readme = readme_file.read()
+with io.open(os.path.join(dir_path, 'VERSION.txt'), encoding='utf-8') as version_file:
+    version = version_file.read().strip()
 base_url = 'https://github.com/sendgrid/'
 
 copy_file(os.path.join(dir_path, 'VERSION.txt'),


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
Removes ResourceWarning on module import and from `setup.py`:
```
$ python -Wd
>>> import python_http_client
/home/<user>/miniconda3/envs/dev/lib/python3.7/site-packages/python_http_client/__init__.py:22: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/<user>/miniconda3/envs/dev/lib/python3.7/site-packages/python_http_client/VERSION.txt' mode='r' encoding='UTF-8'>
  __version__ = open(os.path.join(dir_path, 'VERSION.txt')).read().strip()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

If you have questions, please send an email to the [Twilio SendGrid Developer Experience Team](mailto:dx@sendgrid.com), or file a GitHub Issue in this repository.
