### PR TITLE
fix unclosed version file warning

### DIFF
--- a/python_http_client/__init__.py
+++ b/python_http_client/__init__.py
@@ -19,4 +19,5 @@ from .exceptions import (  # noqa
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 if os.path.isfile(os.path.join(dir_path, 'VERSION.txt')):
-    __version__ = open(os.path.join(dir_path, 'VERSION.txt')).read().strip()
+    with open(os.path.join(dir_path, 'VERSION.txt')) as fh:
+        __version__ = fh.read().strip()


### PR DESCRIPTION
# Fixes #

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation about the functionality in the appropriate .md file
- [] I have added in line documentation to the code I modified

### Short description of what this PR does:
Tiny fix that removes the following unclosed file warning:
```
python -Wd -m unittest discover -v
/src/spython-http-client/python_http_client/__init__.py:22: ResourceWarning: unclosed file <_io.TextIOWrapper name='/src/python-http-client/python_http_client/VERSION.txt' mode='r' encoding='UTF-8'>
  __version__ = open(os.path.join(dir_path, 'VERSION.txt')).read().strip()
```


If you have questions, please send an email to the [Twilio SendGrid Developer Experience Team](mailto:dx@sendgrid.com), or file a GitHub Issue in this repository.
