### PR TITLE
Exclude tests directory from package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import io
 import os
 from distutils.file_util import copy_file
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
@@ -21,11 +21,11 @@ setup(
     author_email='dx@sendgrid.com',
     url='{}python-http-client'.format(base_url),
     download_url='{}python-http-client/tarball/{}'.format(base_url, version),
-    packages=find_packages(),
+    packages=['python_http_client'],
     include_package_data=True,
     license='MIT',
     description='HTTP REST client, simplified for Python',
-    long_description_content_type = 'text/x-rst',
+    long_description_content_type='text/x-rst',
     long_description=readme,
     keywords=[
         'REST',


### PR DESCRIPTION
# Fixes #131 

### Short description of what this PR does:
setup.py includes all packages (containing an __init__.py) using find_packages(). This is a problem because it will include the `tests` directory as a top level importable module in the local app, breaking our own tests that happen to live in a directory with the same name.
