### PR TITLE
feat: Use requests Library to Enable Request Logging

### DIFF
--- a/python_http_client/client.py
+++ b/python_http_client/client.py
@@ -1,16 +1,15 @@
 """HTTP Client library"""
 import json
+import requests
 
 from .exceptions import handle_error
 
 try:
     # Python 3
-    import urllib.request as urllib
     from urllib.parse import urlencode
     from urllib.error import HTTPError
 except ImportError:
     # Python 2
-    import urllib2 as urllib
     from urllib2 import HTTPError
     from urllib import urlencode
 
@@ -24,9 +23,9 @@ class Response(object):
                          on a urllib.build_opener()
         :type response:  urllib response object
         """
-        self._status_code = response.getcode()
-        self._body = response.read()
-        self._headers = response.info()
+        self._status_code = response.status_code
+        self._body = response.content
+        self._headers = response.headers
 
     @property
     def status_code(self):
@@ -171,7 +170,7 @@ class Client(object):
         """
         timeout = timeout or self.timeout
         try:
-            return opener.open(request, timeout=timeout)
+            return opener.send(request, timeout=timeout)
         except HTTPError as err:
             exc = handle_error(err)
             exc.__cause__ = None
@@ -250,9 +249,9 @@ class Client(object):
                             'Content-Type', 'application/json')
                         data = json.dumps(request_body).encode('utf-8')
 
-                opener = urllib.build_opener()
-                request = urllib.Request(
-                    self._build_url(query_params),
+                opener = requests.Session()
+                request = requests.Request(
+                    url=self._build_url(query_params),
                     headers=self.request_headers,
                     data=data,
                 )

--- a/python_http_client/client.py
+++ b/python_http_client/client.py
@@ -251,14 +251,15 @@ class Client(object):
 
                 opener = requests.Session()
                 request = requests.Request(
+                    method=method,
                     url=self._build_url(query_params),
                     headers=self.request_headers,
                     data=data,
                 )
-                request.get_method = lambda: method
+                prepared = request.prepare()
 
                 return Response(
-                    self._make_request(opener, request, timeout=timeout)
+                    self._make_request(opener, prepared, timeout=timeout)
                 )
             return http_request
         else:

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ import os
 from distutils.file_util import copy_file
 from setuptools import setup
 
+requires = [
+    'requests>=2.24.0,<3'
+]
+
 dir_path = os.path.abspath(os.path.dirname(__file__))
 readme_path = os.path.join(dir_path, 'README.rst')
 version_path = os.path.join(dir_path, 'VERSION.txt')
@@ -37,6 +41,7 @@ setup(
         'HTTP',
         'API'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    install_requires=requires,
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -39,7 +39,7 @@ class MockResponse(requests.Response):
 
     def __init__(self, response_code):
         self.status_code = response_code
-        self.content = 'RESPONSE BODY'
+        self._content = 'RESPONSE BODY'
         self.headers = 'HEADERS'
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -124,7 +124,7 @@ class TestClient(unittest.TestCase):
     def test__requests_method(self, maker):
         self.client.delete()
         request = maker.call_args[0][1]
-        self.assertEqual(request.get_method(), 'DELETE')
+        self.assertEqual(request.method, 'DELETE')
 
     def test__update_headers(self):
         request_headers = {'X-Test': 'Test'}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,6 @@
 import pickle
 import unittest
+import requests
 
 from python_http_client.client import Client
 from python_http_client.exceptions import (
@@ -12,11 +13,9 @@ from python_http_client.exceptions import (
 
 try:
     # Python 3
-    import urllib.request as urllib
     from unittest import mock
 except ImportError:
     # Python 2
-    import urllib2 as urllib
     import mock
 
 try:
@@ -36,19 +35,12 @@ class MockException(HTTPError):
         return 'BODY'
 
 
-class MockResponse(urllib.HTTPSHandler):
+class MockResponse(requests.Response):
 
     def __init__(self, response_code):
-        self.response_code = response_code
-
-    def getcode(self):
-        return self.response_code
-
-    def info(self):
-        return 'HEADERS'
-
-    def read(self):
-        return 'RESPONSE BODY'
+        self.status_code = response_code
+        self.content = 'RESPONSE BODY'
+        self.headers = 'HEADERS'
 
 
 class MockClient(Client):
@@ -122,14 +114,14 @@ class TestClient(unittest.TestCase):
         self.assertEqual(built_url, url)
 
     @mock.patch('python_http_client.client.Client._make_request')
-    def test__urllib_headers(self, maker):
+    def test__requests_headers(self, maker):
         self.client._update_headers({'X-test': 'Test'})
         self.client.get()
         request = maker.call_args[0][1]
         self.assertIn('X-test', request.headers)
 
     @mock.patch('python_http_client.client.Client._make_request')
-    def test__urllib_method(self, maker):
+    def test__requests_method(self, maker):
         self.client.delete()
         request = maker.call_args[0][1]
         self.assertEqual(request.get_method(), 'DELETE')


### PR DESCRIPTION
# Fixes #141

This PR switches out the underlying HTTP library. Instead of using `urllib` (and related) which uses `http` under the hood and does not have configuration options for logging requests, we switch to using the `requests` library which uses `urllib3` under the hood and has a module level logger that we can modify to enable request logging.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified